### PR TITLE
First pass looking at the workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ The Istio Ingress Tutorial is largely based on the work of Kelsey and this repos
 
 [https://github.com/kelseyhightower/istio-ingress-tutorial](https://github.com/kelseyhightower/istio-ingress-tutorial)
 
-Kelsey's tutorial uses more advance features of Kubernetes to taint some of the nodes so that the ingress controller runs on dedicated nodes.  The ingress controller is then deployed as a daemonset.
+Kelsey's tutorial uses more advance features of Kubernetes to taint some of the nodes so that the ingress controller runs on dedicated nodes. The ingress controller is then deployed as a daemonset.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The Kubernetes and Istio Exercises are dervied from the work of Ray Tsang  [@sat
 [https://github.com/saturnism/istio-by-example-java](https://github.com/saturnism/istio-by-example-java)
 
 #### Zach Butcher [@ZachButcher](https://twitter.com/ZackButcher)
-Zach was insturmental in helping write the Istio tutorials.
+Zach was instrumental in helping write the Istio tutorials.
 
 ####  Kelsey Hightower [@kelseyhightower](https://twitter.com/kelseyhightower)
 The Istio Ingress Tutorial is largely based on the work of Kelsey and this repository:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -7,7 +7,7 @@ It can be used to describe any Kubernetes resource.
 
 `kubectl describe service helloworld-service`
 
-kubectl top can be used to see resource utilization.  A very common problem is the pod was not able to be scheduled.
+kubectl top can be used to see resource utilization. A very common problem is the pod was not able to be scheduled.
 
 `kubectl top nodes`
 

--- a/exercise-1/README.md
+++ b/exercise-1/README.md
@@ -2,9 +2,10 @@
 
 #### Set Default Region and Zones
 
-`gcloud config set compute/zone us-central1-f`
-
-`gcloud config set compute/region us-central1`
+```sh
+$ gcloud config set compute/zone us-central1-f
+$ gcloud config set compute/region us-central1
+```
 
 #### Create a Kubernetes Cluster using the Google Container Engine.
 
@@ -12,7 +13,9 @@ Google Container Engine is Google’s hosted version of Kubernetes.
 
 Note if you have multiple gcloud accounts then specify a project name using the --project flag.  By default it can be left off.  You can get your project name from the command line with:
 
-`gcloud config get-value core/project`
+```sh
+$ gcloud config get-value core/project
+```
 
 Or the project name can be found in the URL of Google Cloud Console.  For example if you look in the console it should be something like:
 
@@ -20,7 +23,9 @@ https://console.cloud.google.com/kubernetes/list?project=workshopcluster-177619
 
 The project name in that case is workshopcluster-177619
 
-`gcloud container clusters create guestbook --num-nodes 4 --scopes cloud-platform --project <YOUR PROJECT NAME OPTIONAL>`
+```sh
+$ gcloud container clusters create guestbook --num-nodes 4 --scopes cloud-platform --project <YOUR PROJECT NAME OPTIONAL>
+```
 
 ## Explanation
 #### By Ray Tsang [@saturnism](https://twitter.com/saturnism)

--- a/exercise-1/README.md
+++ b/exercise-1/README.md
@@ -3,28 +3,30 @@
 #### Set Default Region and Zones
 
 ```sh
-$ gcloud config set compute/zone us-central1-f
-$ gcloud config set compute/region us-central1
+gcloud config set compute/zone us-central1-f
+```
+```sh
+gcloud config set compute/region us-central1
 ```
 
 #### Create a Kubernetes Cluster using the Google Container Engine.
 
 Google Container Engine is Google’s hosted version of Kubernetes.
 
-Note if you have multiple gcloud accounts then specify a project name using the --project flag.  By default it can be left off.  You can get your project name from the command line with:
+Note if you have multiple gcloud accounts then specify a project name using the --project flag. By default it can be left off. You can get your project name from the command line with:
 
 ```sh
-$ gcloud config get-value core/project
+gcloud config get-value core/project
 ```
 
-Or the project name can be found in the URL of Google Cloud Console.  For example if you look in the console it should be something like:
+Or the project name can be found in the URL of Google Cloud Console. For example if you look in the console it should be something like:
 
 https://console.cloud.google.com/kubernetes/list?project=workshopcluster-177619
 
 The project name in that case is workshopcluster-177619
 
 ```sh
-$ gcloud container clusters create guestbook --num-nodes 4 --scopes cloud-platform --project <YOUR PROJECT NAME OPTIONAL>
+gcloud container clusters create guestbook --num-nodes 4 --scopes cloud-platform --project <YOUR PROJECT NAME OPTIONAL>
 ```
 
 ## Explanation
@@ -32,6 +34,6 @@ $ gcloud container clusters create guestbook --num-nodes 4 --scopes cloud-platfo
 
 This will take a few minutes to run. Behind the scenes, it will create Google Compute Engine instances, and configure each instance as a Kubernetes node. These instances don’t include the Kubernetes Master node. In Google Container Engine, the Kubernetes Master node is managed service so that you don’t have to worry about it!
 
-The scopes parameter is important for this lab. Scopes determine what Google Cloud Platform resources these newly created instances can access.  By default, instances are able to read from Google Cloud Storage, write metrics to Google Cloud Monitoring, etc. For our lab, we add the cloud-platform scope to give us more privileges, such as writing to Cloud Storage as well.
+The scopes parameter is important for this lab. Scopes determine what Google Cloud Platform resources these newly created instances can access. By default, instances are able to read from Google Cloud Storage, write metrics to Google Cloud Monitoring, etc. For our lab, we add the cloud-platform scope to give us more privileges, such as writing to Cloud Storage as well.
 
 #### [Continue to Exercise 2 - Deploying a microservice to Kubernetes](../exercise-2/README.md)

--- a/exercise-10/README.md
+++ b/exercise-10/README.md
@@ -2,71 +2,67 @@
 
 #### Instal Istio Monitoring and Metrics Tools
 
-```
-    kubectl apply -f install/kubernetes/addons/prometheus.yaml
-    kubectl apply -f install/kubernetes/addons/grafana.yaml
-    kubectl apply -f install/kubernetes/addons/servicegraph.yaml
-    kubectl apply -f install/kubernetes/addons/zipkin.yaml
+First we'll install some addons that Istio ships with, so we can get more insight into what's happening in our app:
+```sh
+kubectl apply -f istio-0.2.12/install/kubernetes/addons/prometheus.yaml
+kubectl apply -f istio-0.2.12/install/kubernetes/addons/grafana.yaml
+kubectl apply -f istio-0.2.12/install/kubernetes/addons/servicegraph.yaml
+kubectl apply -f istio-0.2.12/install/kubernetes/addons/zipkin.yaml
 ```
 
 #### Adding Telemetry Rules
 
 Validate that the selected service has no service-specific rules already applied.
 
-```
-  istioctl mixer rule get helloworld-ui.default.svc.cluster.local helloworld-ui.default.svc.cluster.local
-  Error: the server could not find the requested resource
+```sh
+istioctl mixer rule get helloworld-ui.default.svc.cluster.local helloworld-ui.default.svc.cluster.local
+
+Error: the server could not find the requested resource
 ```
 
 Push the new configuration to Mixer for a specific service.
 
-```
-  istioctl mixer rule create helloworld-service.default.svc.cluster.local helloworld-service.default.svc.cluster.local -f telemetry_rule.yaml
-  istioctl mixer rule create helloworld-ui.default.svc.cluster.local helloworld-ui.default.svc.cluster.local -f telemetry_rule.yaml
+```sh
+istioctl mixer rule create helloworld-service.default.svc.cluster.local helloworld-service.default.svc.cluster.local -f telemetry_rule.yaml
+istioctl mixer rule create helloworld-ui.default.svc.cluster.local helloworld-ui.default.svc.cluster.local -f telemetry_rule.yaml
 ```
 
 If the service had service-specific rules you would want to add them to the telemetry rules.
 
-Send traffic to that hello world ui service by either going to the web page or using the curl command.  Refresh the page several times or issue the curl command a few times to generate traffic.
+Send traffic to that hello world ui service by either going to the web page or using the curl command. Refresh the page several times or issue the curl command a few times to generate traffic.
 
+```sh
+watch curl http://$INGRESS_IP/echo/dog2 -A mobile
 ```
-    watch curl http://104.198.198.111/echo/dog2 -A mobile
-```
 
-Verify that the new metric is being collected.  Browse to the Grafana dashboard by viewing the kubernetes services and finding the external IP.  The browse to:
-
-http://104.197.73.207:3000/dashboard/db/istio-dashboard
+Verify that the new metric is being collected. Browse to the Grafana dashboard by viewing the Kubernetes services and finding the external IP. Then view it in your browser: `http://<Grafana IP>/dashboard/db/istio-dashboard`
 
 #### Apply Across the Service mesh
 
 But...that’s tedious to do for every service in your mesh. Instead, let’s apply our telemetry configuration to the whole mesh:
 
-```
-    istioctl mixer rule create global global -f global_telemetry.yaml
+```sh
+istioctl mixer rule create global global -f global_telemetry.yaml
 ```
 
 (Note: we have to use a different config file because in 0.1 Mixer rules are full document writes; in 0.2 configuration is much more granular)
 
 We can also see the logs Mixer creates for our services:
 
-```
-  kubectl logs $(kubectl get pods -l istio=mixer -o jsonpath='{.items[0].metadata.name}') | grep \"combined_log\"
+```sh
+kubectl logs $(kubectl get pods -l istio=mixer -o jsonpath='{.items[0].metadata.name}') | grep \"combined_log\"
 ```
 
 #### Rate Limiting with Mixer
 
 Then apply a 1 request per second rate limit from the UI to the helloworld-service
 
-```
-    istioctl mixer rule create global helloworld-service.default.svc.cluster.local -f rate-limit-ui-service.yaml
+```sh
+istioctl mixer rule create global helloworld-service.default.svc.cluster.local -f rate-limit-ui-service.yaml
 ```
 
 Then we can drive traffic to the UI to see the rate limit in action:
-
+```sh
+watch -n 0.1 curl -i $INGRESS_IP/echo/foo
 ```
-    watch -n 0.1 curl -i <IP>/echo/foo
-```
-
-and in grafana we can see the 429’s.
-
-http://104.197.73.207:3000/dashboard/db/istio-dashboard
+and in Grafana we can see the 429’s: `http://<Grafana IP>/dashboard/db/istio-dashboard`

--- a/exercise-2/README.md
+++ b/exercise-2/README.md
@@ -4,31 +4,38 @@
 
 1 - Deploy hello world service to kubernetes
 
-`kubectl apply -f kubernetes/helloworldservice-deployment.yaml --record`
+```sh
+$ kubectl apply -f kubernetes/helloworldservice-deployment.yaml --record
 
-`kubectl get pods`
-
->NAME                           READY     STATUS    RESTARTS    AGE
-
->helloworld-service-v1-....     1/1       Running   0           20s
+$ kubectl get pods
+NAME                           READY     STATUS    RESTARTS    AGE
+helloworld-service-v1-....     1/1       Running   0           20s
+```
 
 2 -  Note the name of the pod above for use in the command below.  Then delete one of the hello world pods.
 
-`kubectl delete pod helloworld-service-v1-...`
-
+```sh
+$ kubectl delete pod kubernetes/helloworld-service-v1-...
+```
 3 - Kubernetes will automatically restart this pod for you.  Verify it is restarted
 
-`kubectl get pods`
-
->NAME                           READY     STATUS    RESTARTS   AGE
-
->helloworld-service-v1-....     1/1       Running   0          20s
+```sh
+$ kubectl get pods
+NAME                           READY     STATUS    RESTARTS   AGE
+helloworld-service-v1-....     1/1       Running   0          20s
+```
 
 4 -  All of the container output to STDOUT and STDERR will be accessible as Kubernetes logs:
 
-`kubectl logs helloworld-service-v1-...`
+```sh
+$ kubectl logs helloworld-service-v1-...
+```
 
-`kubectl logs -f helloworld-service-v1-...``
+or to follow the log file:
+
+```sh
+$ kubectl logs -f helloworld-service-v1-...
+```
 
 ## Explanation
 

--- a/exercise-2/README.md
+++ b/exercise-2/README.md
@@ -5,49 +5,53 @@
 1 - Deploy hello world service to kubernetes
 
 ```sh
-$ kubectl apply -f kubernetes/helloworldservice-deployment.yaml --record
+kubectl apply -f kubernetes/helloworldservice-deployment.yaml --record
+```
+```sh
+kubectl get pods
 
-$ kubectl get pods
 NAME                           READY     STATUS    RESTARTS    AGE
-helloworld-service-v1-....     1/1       Running   0           20s
+helloworld-service-v1-....    1/1       Running   0           20s
 ```
 
-2 -  Note the name of the pod above for use in the command below.  Then delete one of the hello world pods.
+2 -  Note the name of the pod above for use in the command below. Then delete one of the hello world pods.
 
 ```sh
-$ kubectl delete pod kubernetes/helloworld-service-v1-...
+kubectl delete pod kubernetes/helloworld-service-v1-...
 ```
-3 - Kubernetes will automatically restart this pod for you.  Verify it is restarted
+
+3 - Kubernetes will automatically restart this pod for you. Verify it is restarted
 
 ```sh
-$ kubectl get pods
+kubectl get pods
+
 NAME                           READY     STATUS    RESTARTS   AGE
-helloworld-service-v1-....     1/1       Running   0          20s
+helloworld-service-v1-....    1/1       Running   0          20s
 ```
 
 4 -  All of the container output to STDOUT and STDERR will be accessible as Kubernetes logs:
 
 ```sh
-$ kubectl logs helloworld-service-v1-...
+kubectl logs helloworld-service-v1-...
 ```
 
 or to follow the log file:
 
 ```sh
-$ kubectl logs -f helloworld-service-v1-...
+kubectl logs -f helloworld-service-v1-...
 ```
 
 ## Explanation
 
 #### By Ray Tsang [@saturnism](https://twitter.com/saturnism)
 
-We will be using yaml files throughout this workshop.  Every file describes a resource that needs to be deployed into Kubernetes. We won’t be able to go into details on the contents, but you are definitely encouraged to read them and see how pods, services, and others are declared.
+We will be using yaml files throughout this workshop. Every file describes a resource that needs to be deployed into Kubernetes. We won’t be able to go into details on the contents, but you are definitely encouraged to read them and see how pods, services, and others are declared.
 
 The pod deploys a microservice that is a container whose images contains a self-executing JAR files. The source is available at [istio-by-example-java](https://github.com/saturnism/istio-by-example-java) if you are interested in seeing it.
 
-In this first example we deployed a Kubernetes pod by specifying a deployment using this [helloworldservice-deployment.yaml](helloworldservice-deployment.yaml).  
+In this first example we deployed a Kubernetes pod by specifying a deployment using this [helloworldservice-deployment.yaml](helloworldservice-deployment.yaml). 
 
-A Kubernetes pod is a group of containers, tied together for the purposes of administration and networking. It can contain one or more containers.  All containers within a single pod will share the same networking interface, IP address, volumes, etc.  All containers within the same pod instance will live and die together.  It’s especially useful when you have, for example, a container that runs the application, and another container that periodically polls logs/metrics from the application container.
+A Kubernetes pod is a group of containers, tied together for the purposes of administration and networking. It can contain one or more containers. All containers within a single pod will share the same networking interface, IP address, volumes, etc. All containers within the same pod instance will live and die together. It’s especially useful when you have, for example, a container that runs the application, and another container that periodically polls logs/metrics from the application container.
 
 You can start a single Pod in Kubernetes by creating a Pod resource. However, a Pod created this way would be known as a Naked Pod. If a Naked Pod dies/exits, it will not be restarted by Kubernetes. A better way to start a pod, is by using a higher-level construct such as Replication Controller, Replica Set, or a Deployment.
 

--- a/exercise-2/optional.md
+++ b/exercise-2/optional.md
@@ -3,7 +3,7 @@
 
 `kubectl get pods -owide`
 
-That will list the node the pod is running on.  For example you should see:
+That will list the node the pod is running on. For example you should see:
 
 `NODE gke-guestbook-...`
 

--- a/exercise-3/README.md
+++ b/exercise-3/README.md
@@ -6,15 +6,19 @@ In Kubernetes, you can instruct the underlying infrastructure to create an exter
 
 #### Create the Hello World Service “service”
 
-`kubectl apply -f kubernetes/helloworldservice-service.yaml --record`
+```sh
+$ kubectl apply -f kubernetes/helloworldservice-service.yaml --record
 
-`kubectl get services`
+$ kubectl get services
+```
 
 The external ip will start as pending.  After a short period the EXTERNAL IP will be populated.   This is the external IP of the Load Balancer.   
 
 #### Curl the external ip to test the helloworld service:
 
-`curl 104.154.120.67:8080/hello/world`
+```sh
+$ curl 104.154.120.67:8080/hello/world
+```
 
 #### Explanation
 #### By Ray Tsang [@saturnism](https://twitter.com/saturnism)
@@ -33,8 +37,8 @@ provide a stable IP address, allow discovery from the API, and also create a DNS
 
 If you login into another container you can access the helloworldservice via the DNS name.  For example start  tutum/curl to get a shell and curl the service using the service name:
 
-```
-kubectl run curl --image=tutum/curl -i --tty
+```sh
+$ kubectl run curl --image=tutum/curl -i --tty
 
 root@busybox:/data# wget -qO- http://helloworld-service:8080/hello/Batman
 {"greeting":"Hello Batman from helloworld-service-... with 1.0","hostname":"helloworld-service-...","version":"1.0"}

--- a/exercise-3/README.md
+++ b/exercise-3/README.md
@@ -1,23 +1,28 @@
 ## Exercise 3 - Creating a Kubernetes Service
 
-Each Pod has a unique IP address - but the address is ephemeral.  The Pod IP addresses are not stable and it can change when Pods start and/or restart. A service provides a single access point to a set of pods matching some constraints. A Service IP address is stable.
+Each Pod has a unique IP address - but the address is ephemeral. The Pod IP addresses are not stable and it can change when Pods start and/or restart. A service provides a single access point to a set of pods matching some constraints. A Service IP address is stable.
 
-In Kubernetes, you can instruct the underlying infrastructure to create an external load balancer, by specifying the Service Type as a LoadBalancer.  If you open up [helloworldservice-service.yaml](helloworldservice-service.yaml) you will see that it has a type: LoadBalancer
+In Kubernetes, you can instruct the underlying infrastructure to create an external load balancer, by specifying the Service Type as a LoadBalancer. If you open up [helloworldservice-service.yaml](helloworldservice-service.yaml) you will see that it has a type: LoadBalancer
 
 #### Create the Hello World Service “service”
 
 ```sh
-$ kubectl apply -f kubernetes/helloworldservice-service.yaml --record
-
-$ kubectl get services
+kubectl apply -f kubernetes/helloworldservice-service.yaml --record
 ```
 
-The external ip will start as pending.  After a short period the EXTERNAL IP will be populated.   This is the external IP of the Load Balancer.   
+```sh
+kubectl get services
+
+NAME                 TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)          AGE
+helloworld-service   LoadBalancer   10.0.0.208   <pending>     8080:31771/TCP   9s
+```
+
+The external ip will start as pending. After a short period the EXTERNAL IP will be populated.  This is the external IP of the Load Balancer.  
 
 #### Curl the external ip to test the helloworld service:
 
 ```sh
-$ curl 104.154.120.67:8080/hello/world
+curl 104.154.120.67:8080/hello/world
 ```
 
 #### Explanation
@@ -25,7 +30,7 @@ $ curl 104.154.120.67:8080/hello/world
 
 Open the [helloworldservice-service.yaml](helloworldservice-service.yaml) to examine the service descriptor. The important part about this file is the selector section. This is how a service knows which pod to route the traffic to, by matching the selector labels with the labels of the pods.
 
-The other important part to notice in this file is the type of service is a Load Balancer.  This tells GCE that an externally facing load balancer should be created for this service so that it is accessible from the outside.
+The other important part to notice in this file is the type of service is a Load Balancer. This tells GCE that an externally facing load balancer should be created for this service so that it is accessible from the outside.
 
 Since we are running two instances of the Hello World Service (one instance in one pod), and that the IP addresses are not only unique, but also ephemeral - how will a client reach our services? We need a way to discover the service.
 
@@ -35,7 +40,7 @@ provide a stable IP address, allow discovery from the API, and also create a DNS
 
 #### Optional - curl the service using a DNS name
 
-If you login into another container you can access the helloworldservice via the DNS name.  For example start  tutum/curl to get a shell and curl the service using the service name:
+If you login into another container you can access the helloworldservice via the DNS name. For example start  tutum/curl to get a shell and curl the service using the service name:
 
 ```sh
 $ kubectl run curl --image=tutum/curl -i --tty

--- a/exercise-4/README.md
+++ b/exercise-4/README.md
@@ -4,34 +4,50 @@
 
 1 - Scaling the number of replicas of our Hello World service is as simple as running :
 
-`kubectl get deployment`
+```sh
+$ kubectl get deployment
+NAME                    DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+helloworld-service-v1   1         1         1            1           1m
 
-`kubectl scale deployment helloworld-service-v1 --replicas=4`
+$ kubectl scale deployment helloworld-service-v1 --replicas=4
+$ kubectl get deployment
+NAME                    DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+helloworld-service-v1   4         4         4            4           1m
 
-`kubectl get deployment`
-
-`kubectl get pods`
+$ kubectl get pods
+NAME                          READY     STATUS    RESTARTS   AGE
+helloworld-service-v1-...     1/1       Running   0          1m
+helloworld-service-v1-...     1/1       Running   0          1m
+helloworld-service-v1-...     1/1       Running   0          1m
+helloworld-service-v1-...     1/1       Running   0          2m
+```
 
 2 - Scale out even more
 
-`kubectl scale deployment helloworld-service-v1 --replicas=12`
+```sh
+$ kubectl scale deployment helloworld-service-v1 --replicas=12
+```
 
 If you look at the pod status some of the Pods will show a `Pending` state.   That is because we only have four physical nodes, and the underlying infrastructure has run out of capacity to run the containers with the requested resources.
 
 3 - Pick a Pod name that is associated with the Pending state to confirm the lack of resources in the detailed status:
 
-`kubectl describe pod helloworld-service...`
+```sh
+$ kubectl describe pod helloworld-service...
+```
 
 4 - We can easily spin up another Compute Engine instance to append to the cluster.
 
-`gcloud container clusters resize guestbook --size=5`
-
-`gcloud compute instances list`
+```sh
+$ gcloud container clusters resize guestbook --size=5
+$ gcloud compute instances list
+```
 
 5 - Verify the new instance has joined the Kubernetes cluster, you’ll should be able to see it with this command:
 
-`kubectl get nodes`
-
-`kubectl scale deployment helloworld-service-v1 --replicas=4`
+```sh
+$ kubectl get nodes
+$ kubectl scale deployment helloworld-service-v1 --replicas=4
+```
 
 #### [Continue to Exercise 5 - Installing Istio](../exercise-5/README.md)

--- a/exercise-4/README.md
+++ b/exercise-4/README.md
@@ -5,49 +5,63 @@
 1 - Scaling the number of replicas of our Hello World service is as simple as running :
 
 ```sh
-$ kubectl get deployment
+kubectl get deployment
+
 NAME                    DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 helloworld-service-v1   1         1         1            1           1m
+```
 
-$ kubectl scale deployment helloworld-service-v1 --replicas=4
-$ kubectl get deployment
+```sh
+kubectl scale deployment helloworld-service-v1 --replicas=4
+```
+
+```sh
+kubectl get deployment
+
 NAME                    DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 helloworld-service-v1   4         4         4            4           1m
+```
 
-$ kubectl get pods
+```sh
+kubectl get pods
+
 NAME                          READY     STATUS    RESTARTS   AGE
-helloworld-service-v1-...     1/1       Running   0          1m
-helloworld-service-v1-...     1/1       Running   0          1m
-helloworld-service-v1-...     1/1       Running   0          1m
-helloworld-service-v1-...     1/1       Running   0          2m
+helloworld-service-v1-...    1/1       Running   0          1m
+helloworld-service-v1-...    1/1       Running   0          1m
+helloworld-service-v1-...    1/1       Running   0          1m
+helloworld-service-v1-...    1/1       Running   0          2m
 ```
 
 2 - Scale out even more
 
 ```sh
-$ kubectl scale deployment helloworld-service-v1 --replicas=12
+kubectl scale deployment helloworld-service-v1 --replicas=12
 ```
 
-If you look at the pod status some of the Pods will show a `Pending` state.   That is because we only have four physical nodes, and the underlying infrastructure has run out of capacity to run the containers with the requested resources.
+If you look at the pod status some of the Pods will show a `Pending` state.  That is because we only have four physical nodes, and the underlying infrastructure has run out of capacity to run the containers with the requested resources.
 
 3 - Pick a Pod name that is associated with the Pending state to confirm the lack of resources in the detailed status:
 
 ```sh
-$ kubectl describe pod helloworld-service...
+kubectl describe pod helloworld-service...
 ```
 
 4 - We can easily spin up another Compute Engine instance to append to the cluster.
 
 ```sh
-$ gcloud container clusters resize guestbook --size=5
-$ gcloud compute instances list
+gcloud container clusters resize guestbook --size=5
+```
+```sh
+gcloud compute instances list
 ```
 
 5 - Verify the new instance has joined the Kubernetes cluster, you’ll should be able to see it with this command:
 
 ```sh
-$ kubectl get nodes
-$ kubectl scale deployment helloworld-service-v1 --replicas=4
+kubectl get nodes
+```
+```sh
+kubectl scale deployment helloworld-service-v1 --replicas=4
 ```
 
 #### [Continue to Exercise 5 - Installing Istio](../exercise-5/README.md)

--- a/exercise-5/README.md
+++ b/exercise-5/README.md
@@ -5,7 +5,7 @@
 Start with a clean slate and delete all deployed services from the cluster:
 
 ```sh
-$ kubectl delete all --all
+kubectl delete all --all
 ```
 
 #### Download Istio
@@ -15,45 +15,46 @@ Either download it directly or get the latest using curl:
 https://github.com/istio/istio/releases
 
 ```sh
-$ curl -L https://git.io/getLatestIstio | sh -
-$ export PATH=$PWD/istio-0.2.10/bin:$PATH
+curl -L https://git.io/getLatestIstio | sh -
+```
+```sh
+export PATH=$PWD/istio-0.2.12/bin:$PATH
 ```
 
 #### Running istioctl
 
-Istio related commands need to have `istioctl` in the path.  Verify it is available by running:
+Istio related commands need to have `istioctl` in the path. Verify it is available by running:
 
 ```sh
-$ istioctl -h
+istioctl -h
 ```
-
 
 #### Install Istio on the Kubernetes Cluster
 
 1 - First grant cluster admin permissions to the current user (admin permissions are required to create the necessary RBAC rules for Istio):
 
 ```sh
-$ kubectl create clusterrolebinding cluster-admin-binding \
+kubectl create clusterrolebinding cluster-admin-binding \
     --clusterrole=cluster-admin \
     --user=$(gcloud config get-value core/account)
 ```
 2 - Next install Istio on the Kubernetes cluster:
 
-Change to the Istio directory (istio-0.2.10) and and install istio in the kubernetes cluster
+Change to the Istio directory (istio-0.2.12) and and install istio in the kubernetes cluster
 
 ```sh
-$ cd istio-0.2.10
-$ kubectl apply -f install/kubernetes/istio.yaml
+kubectl apply -f istio-0.2.12/install/kubernetes/istio.yaml
 ```
-
 
 #### Viewing the Istio Deployments
 
-Istio is deployed in a separate Kubernetes namespace `istio-system`  You can watch the state of Istio and other services and pods using the watch command.  For example in 2 separate terminal windows run:
+Istio is deployed in a separate Kubernetes namespace `istio-system`  You can watch the state of Istio and other services and pods using the watch flag (`-w`) when listing Kubernetes resources. For example, in two separate terminal windows run:
 
+```sh
+kubectl get pods -w --all-namespaces
 ```
-$ kubectl get pods -w --all-namespaces
-$ kubectl get services -w --all-namespaces
+```sh
+kubectl get services -w --all-namespaces
 ```
 
 #### [Continue to Exercise 6 - Creating a Service Mesh with Istio Proxy](../exercise-6/README.md)

--- a/exercise-5/README.md
+++ b/exercise-5/README.md
@@ -4,8 +4,8 @@
 
 Start with a clean slate and delete all deployed services from the cluster:
 
-```
-    kubectl delete all
+```sh
+$ kubectl delete all --all
 ```
 
 #### Download Istio
@@ -14,34 +14,36 @@ Either download it directly or get the latest using curl:
 
 https://github.com/istio/istio/releases
 
-```
-curl -L https://git.io/getLatestIstio | sh -
-export PATH=$PWD/istio-0.2.10/bin:$PATH
+```sh
+$ curl -L https://git.io/getLatestIstio | sh -
+$ export PATH=$PWD/istio-0.2.10/bin:$PATH
 ```
 
 #### Running istioctl
 
 Istio related commands need to have `istioctl` in the path.  Verify it is available by running:
 
-`istioctl -h`
+```sh
+$ istioctl -h
+```
 
 
 #### Install Istio on the Kubernetes Cluster
 
 1 - First grant cluster admin permissions to the current user (admin permissions are required to create the necessary RBAC rules for Istio):
 
-```
-    kubectl create clusterrolebinding cluster-admin-binding \
-        --clusterrole=cluster-admin \
-        --user=$(gcloud config get-value core/account)
+```sh
+$ kubectl create clusterrolebinding cluster-admin-binding \
+    --clusterrole=cluster-admin \
+    --user=$(gcloud config get-value core/account)
 ```
 2 - Next install Istio on the Kubernetes cluster:
 
 Change to the Istio directory (istio-0.2.10) and and install istio in the kubernetes cluster
 
-```
-    cd istio-0.2.10
-    kubectl apply -f install/kubernetes/istio.yaml
+```sh
+$ cd istio-0.2.10
+$ kubectl apply -f install/kubernetes/istio.yaml
 ```
 
 
@@ -50,8 +52,8 @@ Change to the Istio directory (istio-0.2.10) and and install istio in the kubern
 Istio is deployed in a separate Kubernetes namespace `istio-system`  You can watch the state of Istio and other services and pods using the watch command.  For example in 2 separate terminal windows run:
 
 ```
-  watch -n 30 kubectl get po --all-namespaces
-  watch -n 30 kubectl get svc --all-namespaces
+$ kubectl get pods -w --all-namespaces
+$ kubectl get services -w --all-namespaces
 ```
 
 #### [Continue to Exercise 6 - Creating a Service Mesh with Istio Proxy](../exercise-6/README.md)

--- a/exercise-6/README.md
+++ b/exercise-6/README.md
@@ -2,70 +2,76 @@
 
 #### What is a Service Mesh?
 
-Cloud Native Applications require a new approach to managing the communication between each service.  This problem is best solved by creating a dedicated infrastructure layer that handles service-to-service communication. With Istio this infrastructure layer is created by deploying a lightweight proxy alongside each application service.  It is done in a way that the application does not need to be aware of the proxy.
+Cloud Native Applications require a new approach to managing the communication between each service. This problem is best solved by creating a dedicated infrastructure layer that handles service-to-service communication. With Istio this infrastructure layer is created by deploying a lightweight proxy alongside each application service. It is done in a way that the application does not need to be aware of the proxy.
 
 By moving the service communication to a separate layer it provides a separation of concerns where the monitoring, management and security of communication can be handled outside of the application logic.
 
 #### Istio Proxy Side Car
 
-To create a service mesh with Istio we update the deployment of the Pods to add the Istio Proxy (based on the Lyft Envoy Proxy) as a side car to each Pod.  The Proxy is then run as a separate container that manages all communication with that Pod.  This can be done either manually or with the latest version of Kubernetes automatically.
+To create a service mesh with Istio we update the deployment of the Pods to add the Istio Proxy (based on the Lyft Envoy Proxy) as a side car to each Pod. The Proxy is then run as a separate container that manages all communication with that Pod. This can be done either manually or with the latest version of Kubernetes automatically.
 
-Manually the side car can be injected by running the istioctl kube-inject command which modifies the yaml file before creating the deployments.  This injects the Proxy into the deployment by updating the YAML to add the Proxy as a sidecar.  When this command is used the microservices are now packaged with an Proxy sidecar that manages incoming and outgoing calls for the service.  
+Manually the side car can be injected by running the istioctl kube-inject command which modifies the yaml file before creating the deployments. This injects the Proxy into the deployment by updating the YAML to add the Proxy as a sidecar. When this command is used the microservices are now packaged with an Proxy sidecar that manages incoming and outgoing calls for the service. 
 
-Istio sidecars can also be automatically injected into a Pod before deployment using an alpha feature in Kubernetes called Initializers.  We will not be covering that feature in this workshop.
+Istio sidecars can also be automatically injected into a Pod before deployment using an alpha feature in Kubernetes called Initializers. We will not be covering that feature in this workshop.
 
 To see how the deployment yaml is modified run the following command:
 
-```
-    istioctl kube-inject -f guestbook/helloworld-deployment.yaml
+```sh
+istioctl kube-inject -f guestbook/helloworld-deployment.yaml
 ```
 
 Inside the yaml there is now an additional container:
 
 ```
-  image: docker.io/istio/proxy_debug:0.2.9
-  imagePullPolicy: IfNotPresent
-  name: istio-proxy
+image: docker.io/istio/proxy_debug:0.2.9
+imagePullPolicy: IfNotPresent
+name: istio-proxy
 ```
 
 This adds the Istio Proxy as an additional container to the Pod and setups the necessary configuration.
 
 #### Deploy all of the Guest Book Services to get started
 
-To deploy all of the guest book related components each deployment needs to be wrapped with a call to istioctl.  The following script does this for each of the components.
+To deploy all of the guest book related components each deployment needs to be wrapped with a call to istioctl. The following script does this for each of the components.
 
 1 - Start the Guest Book services using the following script - note there is a delay between when the services get deployed because of interdependencies required to start the services:
 
-```
-    guestbook/deployGuestBookIstio.sh
+```sh
+./guestbook/deployGuestBookIstio.sh
 ```
 
 Note for windows -  You will need to manually run each command from that file and set the directly properly.
 
 2 - Find the public IP of the Guest Book UI by running describe on the service and look for EXTERNAL-IP in the output (it will take several minutes to be assigned, so give it a minute or two):
 
-```
-    kubectl describe services guestbook-ui
+```sh
+kubectl describe services guestbook-ui
 ```
 
-3 - Access the guestbook via the Guest Book EXTERNAL-IP address by navigating the browser to http://EXTERNAL-IP/.
-
-4 - The Guest Book UI also has a rest endpoint that can be used for testing routing rules.  It takes the last part of the URL as the name to create a greeting for.  Verify it works by running:
-
+```sh
+export EXTERNAL_IP=<IP from above>
 ```
-    curl http://EXTERNAL-IP/echo/universe
+
+3 - Access the guestbook via the Guest Book EXTERNAL-IP address by navigating the browser to http://<EXTERNAL IP>/.
+
+4 - The Guest Book UI also has a rest endpoint that can be used for testing routing rules. It takes the last part of the URL as the name to create a greeting for. Verify it works by running:
+
+```sh
+curl http://$EXTERNAL_IP/echo/universe
 ```
 
 5 - Try curling the echo endpoint multiple times and notice how it round robins between v1 and v2 of the hello world service:
 
+```sh
+curl $EXTERNAL_IP/echo/universe
+
+{"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},
 ```
-  $ curl 146.148.33.1/echo/universe
 
-  {"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},
+```sh
+curl $EXTERNAL_IP/echo/universe
 
-  $ curl 146.148.33.1/echo/universe
-
-  {"greeting":{"hostname":"helloworld-service-v2-1009285752-n2tpb","greeting":"Hello universe from helloworld-service-v2-1009285752-n2tpb with 2.0","version":"2.0"}
+{"greeting":{"hostname":"helloworld-service-v2-1009285752-n2tpb","greeting":"Hello universe from helloworld-service-v2-1009285752-n2tpb with 2.0","version":"2.0"}
 
 ```
 

--- a/exercise-7/README.md
+++ b/exercise-7/README.md
@@ -1,6 +1,6 @@
 ## Exercise 7 - Istio Ingress Controller
 
-The components deployed on the service mesh by default are not exposed outside the cluster.  External access to individual services so far has been provided by creating an external load balancer on each service.  
+The components deployed on the service mesh by default are not exposed outside the cluster. External access to individual services so far has been provided by creating an external load balancer on each service. 
 
 A Kubernetes Ingress rule can be created that routes external requests through the Istio Ingress Controller to the backing services.
 
@@ -8,38 +8,55 @@ A Kubernetes Ingress rule can be created that routes external requests through t
 
 1 - Configure the Guess Book UI default route with the Istio Ingress Controller:
 
-```
+```sh
 kubectl apply -f guestbook/guestbook-ingress.yaml
 ```
 
 In this file notice that the ingress class is specified as   `kubernetes.io/ingress.class: istio` which routes the request to Istio.
 
-The second thing to notice is that the request is routed to different services, either helloworld-service or guestbook-ui depending on the request.  
+The second thing to notice is that the request is routed to different services, either helloworld-service or guestbook-ui depending on the request. We can see how this works by having Kubernetes describe the ingress resource for us:
+
+```sh
+kubectl describe ingress
+
+Name:             simple-ingress
+Namespace:        default
+Address:          
+Default backend:  default-http-backend:80 (<none>)
+Rules:
+  Host  Path  Backends
+  ----  ----  --------
+  *     
+        /hello/.*   helloworld-service:8080 (<none>)
+        /.*         guestbook-ui:80 (<none>)
+Annotations:
+Events:  <none>
+
+```
 
 2 - Find the external IP of the Istio Ingress controller:
 
-```
+```sh
 kubectl get svc -n istio-system
 
 NAMESPACE      NAME                   CLUSTER-IP      EXTERNAL-IP      PORT(S)                                                  AGE
 istio-system   istio-ingress          10.31.244.185   35.188.171.180   80:31920/TCP,443:32165/TCP                               1h
-
 ```
 
-3 - Browse to the website of the guest Book using the INGRESS IP to see the Guest Book UI.  
-
-http://INGRESS_IP/hello/world
-
-Also you should be able to curl the Guest Book using:
-
-```
-curl http://INGRESS_IP/echo/universe  
+```sh
+export INGRESS_IP=<External IP from above>
 ```
 
-And the hello world service with:
+3 - Browse to the website of the guest Book using the INGRESS IP to see the Guest Book UI: `http://INGRESS_IP/hello/world`
 
+You can also curl the Guest Book:
 ```
-http://INGRESS_IP/hello/world
+curl http://$INGRESS_IP/echo/universe
+```
+
+And the hello world service:
+```
+http://$INGRESS_IP/hello/world
 ```
 
 #### [Continue to Exercise 8 - Request Routing and Canary Deployments](../exercise-8/README.md)

--- a/exercise-8/README.md
+++ b/exercise-8/README.md
@@ -1,6 +1,6 @@
 ## Exercise 8 - Request Routing and Canary Deployments
 
-Because there are 2 version of the HelloWorld Service Deployment (v1 and v2), before modifying any of the routes a default route needs to be set to just V1.  Otherwise it will just round robin between V1 and V2
+Because there are 2 version of the HelloWorld Service Deployment (v1 and v2), before modifying any of the routes a default route needs to be set to just V1. Otherwise it will just round robin between V1 and V2
 
 #### Configure the default route for hello world service
 
@@ -10,87 +10,100 @@ Because there are 2 version of the HelloWorld Service Deployment (v1 and v2), be
 istioctl create -f guestbook/route-rule-force-hello-v1.yaml
 ```
 
-This ingress rule forces v1 of the service by giving it a weight of 100.
+This ingress rule forces `v1` of the service by giving it a weight of 100. We can see this by describing the resource we created:
+```sh
+kubectl describe routerules helloworld-default
+
+Name:         helloworld-default
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+API Version:  config.istio.io/v1alpha2
+Kind:         RouteRule
+Metadata:
+  ...
+Spec:
+  Destination:
+    Name:      helloworld-service
+  Precedence:  1
+  Route:
+    Labels:
+      Version:  1.0
+```
 
 2 - Now when you curl the echo service it should always return V1 of the hello world service:
 
+```sh
+curl 35.188.171.180/echo/universe  
+
+{"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},"
 ```
-$ curl 35.188.171.180/echo/universe  
+```sh
+curl 35.188.171.180/echo/universe
 
 {"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},"
-
-$ curl 35.188.171.180/echo/universe
-
-{"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},"
-
 ```
 
 #### Canary Deployments
 
-Currently the routing rule routes only to V1 of the hello world service which is not real useful. What we want to do next is a canary deployment and push some of the traffic to V2. This can be done by creating another rule with a higher precedence that routes some of the traffic to V2 based on http headers.  As an example we will use the following canary deployment in canary-helloworld.yaml  This rule routes all traffic from a mobile user agent to version 2.0 of the service.
-
-```
-    destination:
-      name: helloworld-service
-    match:
-      request:
-        headers:
-          user-agent:
-            exact: mobile
-    precedence: 2
-    route:
-      - labels:
-          version: "2.0"
-```
-
-Note that rules with a higher precedence number are applied first.  If a precedence is not specified then it defaults to 0.  So with these 2 rules in place the one with precedence 2 will be applied first.
-
-Test this out by creating the rule:
-
-```
-    istioctl create -f guestbook/route-rule-canary.yaml
-```
-
-Now when you curl the end point set the user agent to be mobile and you should only see V2:
-
-```
-$ curl http://104.198.198.111/echo/universe -A mobile
-
-{"greeting":{"hostname":"helloworld-service-v2-3297856697-6m4bp","greeting":"Hello dog2 from helloworld-service-v2-3297856697-6m4bp with 2.0","version":"2.0"}
-
-$ curl 35.188.171.180/echo/universe
-
-{"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},"
-
-```
-
-An important point to note is that the user-agent http header is propagated in the span baggage.  Look at these two classes for details:
-
-https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanInjector.java
-
-https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanExtractor.java
-
-#### Optional - Route based on the browser
-
-It is also possible to route it based on the Web Browser.  For example the following routes to version 2.0 if the browser is chrome:
-
-```
-  match:
-    request:
-      headers:
-        user-agent:
-          regex: ".*Chrome.*"
-  route:
+Currently the routing rule only routes to `v1` of the hello world service which. What we want to do is canary a deployment of `v2` of the hello world service by allowing only a small amount of traffic to it. This can be done by creating another rule with a higher precedence that routes some of the traffic to `v2`. We'll canary based on HTTP headers: if the user-agent is "mobile" it'll go to `v2`, otherwise requests will go to `v1`. Written as a route rule, this looks like:
+```yaml
+destination:
+  name: helloworld-service
+match:
+  request:
+    headers:
+      user-agent:
+        exact: mobile
+precedence: 2
+route:
   - labels:
       version: "2.0"
 ```
 
+Note that rules with a higher precedence number are applied first. If a precedence is not specified then it defaults to 0. So with these two rules in place the one with precedence 2 will be applied before the rule with precedence 1.
+
+Test this out by creating the rule:
+```sh
+istioctl create -f guestbook/route-rule-canary.yaml
+```
+
+Now when you curl the end point set the user agent to be mobile and you should only see V2:
+
+```sh
+curl http://$INGRESS_IP/echo/universe -A mobile
+
+{"greeting":{"hostname":"helloworld-service-v2-3297856697-6m4bp","greeting":"Hello dog2 from helloworld-service-v2-3297856697-6m4bp with 2.0","version":"2.0"}
+```
+```sh
+$ curl $INGRESS_IP/echo/universe
+
+{"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},"
+```
+
+An important point to note is that the user-agent http header is propagated in the span baggage. Look at these two classes for details on how the header is [injected](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanInjector.java) and [extracted](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanExtractor.java):
+
+#### Optional - Route based on the browser
+
+It is also possible to route it based on the Web Browser. For example the following routes to version 2.0 if the browser is chrome:
+
+```yaml
+match:
+  request:
+    headers:
+      user-agent:
+        regex: ".*Chrome.*"
+route:
+- labels:
+    version: "2.0"
+```
+
 To apply this route run:
 
-```
-    istioctl create -f guestbook/route-rule-user-agent-chrome.yaml
+```sh
+istioctl create -f guestbook/route-rule-user-agent-chrome.yaml
 ```
 
-Then navigate to the home page in chrome and another browser.
+Then navigate to the home page in Chrome and another browser.
 
 #### [Continue to Exercise 9 - Fault Injection](../exercise-9/README.md)

--- a/exercise-9/README.md
+++ b/exercise-9/README.md
@@ -2,48 +2,48 @@
 
 #### Overview of Istio Mixer
 
-https://istio.io/docs/concepts/policy-and-control/mixer.html
+See the overview of Mixer at [istio.io](https://istio.io/docs/concepts/policy-and-control/mixer.html).
 
 #### Setting Up Mixer for Kubernetes
 
 First we configure Mixer for a kubernetes environment, setting up the kubernetes adapter to produce attributes about the kubernetes deployment (e.g. the labels on the target and source pods).
 
-```
-    istioctl mixer rule create global global -f guestbook/mixer-kubernetes.yaml
+```sh
+istioctl mixer rule create global global -f guestbook/mixer-kubernetes.yaml
 ```
 
 #### Service Isolation Using Mixer
 
 Block Access to the hello world service by adding the mixer-rule-denial.yaml rule shown below:
 
-```
-  rules:
-    - selector: source.labels["app"]=="helloworld-ui"
-      aspects:
-      - kind: denials
+```yaml
+rules:
+  - selector: source.labels["app"]=="helloworld-ui"
+    aspects:
+    - kind: denials
 ```
 
-```
-    istioctl mixer rule create global helloworld-service.default.svc.cluster.local -f guestbook/mixer-rule-denial.yaml
+```sh
+istioctl mixer rule create global helloworld-service.default.svc.cluster.local -f guestbook/mixer-rule-denial.yaml
 ```
 
 #### Block Access to v2 of the hello world service
 
-```
-    rules:
-      - selector: destination.labels["app"]=="helloworld-ui" && source.labels["version"] == "v2"
-        aspects:
-        - kind: denials
+```yaml
+rules:
+  - selector: destination.labels["app"]=="helloworld-ui" && source.labels["version"] == "v2"
+    aspects:
+    - kind: denials
 ```
 
-```
-  istioctl mixer rule create global helloworld-service.default.svc.cluster.local -f mixer-rule-denial-v2.yaml
+```sh
+istioctl mixer rule create global helloworld-service.default.svc.cluster.local -f mixer-rule-denial-v2.yaml
 ```
 
 Then we clean up the rules to get everything working again:
 
-```
-  istioctl mixer rule delete global helloworld-service.default.svc.cluster.local
+```sh
+istioctl mixer rule delete global helloworld-service.default.svc.cluster.local
 ```
 
 #### [Continue to Exercise 10 - Telemetry and Rate Limiting with Mixer](../exercise-10/README.md)


### PR DESCRIPTION
Touch up code blocks everywhere:
- remove indentation
- add annotations for syntax highlighting blocks
- remove extra spaces at the beginning of commands
- touch up a few commands so that everything can be run from the root of
the istio-workshop directory (no cd'ing around during the workshop)

Remove double spaces after periods globally.

Reword a few things.

<hr>

Couple other questions I have after going through it:
- Why do we use `istio.yaml` and not `istio-auth.yaml` (which sets up the CA and tells Envoy to use mTLS on all in-mesh connections).
- Is there a good reason not to use the initializer, and remove the shell scripts that handle `istioctl kube-inject`'ing the deployments? We can still talk through what kube-inject does, but with the initializer everyone can use regular old kube commands to deploy everything and we can get rid of the shell scripts. I also like dumping the sleeps in those scripts.
- I'm seeing the product page UI fail a lot when I first start it up. In particular, it times out a lot. Any idea why?
- We should update all the curl commands to either have an `http` prefix or not, right now there's a mix of both.

The biggest issue though is that all of the mixer stuff in exercises 9 and 10 need to be rewritten using CRDs. In fact, `istioctl mixer` doesn't even work in 0.2.