### PR TITLE
Updated workshop

### DIFF
--- a/exercise-1/README.md
+++ b/exercise-1/README.md
@@ -18,15 +18,25 @@ If you have multiple gcloud accounts then be sure the correct one is specified f
 gcloud config get-value core/project
 ```
 
-If needed you can set a new project id.  Note: For the Scale by the Bay workshop you should already have a project in you Google Cloud account configured called scalebay17-sfo-SOME_NUMBER.  Take note of the `SOME_NUMBER` and use it in the following command.
+If you are in an instructor led class with a provided credential, then you don't need to set another project ID.
+
+If you are using you are not using an instructor provided credentials, then you may need to specify a project ID:
 
 ```sh
-gcloud config set project scalebay17-sfo-SOME_NUMBER
+gcloud config set project your-project-id
 ```
 
-#### Create a Kubernetes Cluster using the Google Container Engine.
+#### Enable Compute Engine and Kubernetes Engine API
 
-Google Container Engine is Google’s hosted version of Kubernetes.
+```sh
+gcloud services enable \
+  compute.googleapis.com \
+  container.googleapis.com
+```
+
+#### Create a Kubernetes Cluster using the Google Kubernetes Engine
+
+Google Kubernetes Engine is Google’s hosted version of Kubernetes.
 
 To create a container cluster execute:
 
@@ -34,8 +44,7 @@ To create a container cluster execute:
 gcloud container clusters create guestbook \
       --cluster-version=1.9.2-gke.1  \
       --num-nodes 3 \
-      --machine-type "n1-standard-2" \
-      --scopes cloud-platform
+      --machine-type n1-standard-2
 ```
 
 #### Verify kubectl
@@ -44,8 +53,6 @@ gcloud container clusters create guestbook \
 ## Explanation
 #### By Ray Tsang [@saturnism](https://twitter.com/saturnism)
 
-This will take a few minutes to run. Behind the scenes, it will create Google Compute Engine instances, and configure each instance as a Kubernetes node. These instances don’t include the Kubernetes Master node. In Google Container Engine, the Kubernetes Master node is managed service so that you don’t have to worry about it!
-
-The scopes parameter is important for this lab. Scopes determine what Google Cloud Platform resources these newly created instances can access. By default, instances are able to read from Google Cloud Storage, write metrics to Google Cloud Monitoring, etc. For our lab, we add the cloud-platform scope to give us more privileges, such as writing to Cloud Storage as well.
+This will take a few minutes to run. Behind the scenes, it will create Google Compute Engine instances, and configure each instance as a Kubernetes node. These instances don’t include the Kubernetes Master node. In Google Kubernetes Engine, the Kubernetes Master node is managed service so that you don’t have to worry about it!
 
 #### [Continue to Exercise 2 - Deploying a microservice to Kubernetes](../exercise-2/README.md)

--- a/exercise-10/README.md
+++ b/exercise-10/README.md
@@ -56,7 +56,25 @@ curl http://$INGRESS_IP/echo/universe
 
 #### Canary Testing
 
-Currently the routing rule only routes to `v1` of the hello world service which. What we want to do is a deployment of `v2` of the hello world service by allowing only a small amount of traffic to it from a small group. This can be done by creating another rule with a higher precedence that routes some of the traffic to `v2`. We'll do canary testing based on HTTP headers: if the user-agent is "mobile" it'll go to `v2`, otherwise requests will go to `v1`. Written as a route rule, this looks like:
+Currently the routing rule only routes to `v1` of the hello world service which. What we want to do is a deployment of `v2` of the Hello World service by allowing only a small amount of traffic to it from a small group. This can be done by creating another rule with a higher precedence that routes some of the traffic to `v2`. We can do canary testing by splitting traffic between the 2 versions:
+
+```yaml
+  destination: helloworld-service.default.svc.cluster.local
+  precedence: 1
+  route:
+  - tags:
+      version: "1.0"
+    weight: 80
+  - tags:
+      version: "2.0"
+    weight: 20
+```
+
+We'll do canary testing based on HTTP headers: if the user-agent is "mobile" it'll go to `v2`, otherwise requests will go to `v1`. Written as a route rule, this looks like:
+
+```sh
+istioctl create -f guestbook/route-rule-80-20.yaml
+```
 
 ```yaml
 destination:

--- a/exercise-10/README.md
+++ b/exercise-10/README.md
@@ -5,12 +5,12 @@
 Envoy proxies call Mixer to report statistics and check for route rules. By opening up some of the mixer ports we can get an of idea what calls its seeing:
 
 ```sh
-kubectl get po -n istio-system
-kubectl  port-forward -n istio-system istio-mixer-65bb55df98-s47ns 9093:9093
+kubectl get pods -n istio-system
+kubectl port-forward -n istio-system istio-mixer-... 9093:9093
 curl localhost:9093/metrics
 ```
 
-#### Configure the default route for hello world service
+#### Configure the default route for Hello World service V1
 
 Because there are 2 version of the HelloWorld Service Deployment (v1 and v2), before modifying any of the routes a default route needs to be set to just V1. Otherwise it will just round robin between V1 and V2
 
@@ -93,7 +93,7 @@ curl http://$INGRESS_IP/echo/universe
 {"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},"
 ```
 
-An important point to note is that the user-agent http header is propagated in the span baggage. Look at these two classes for details on how the header is [injected](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanInjector.java) and [extracted](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanExtractor.java):
+An important point to note is that the user-agent HTTP header is propagated in the span baggage. Look at these two classes for details on how the header is [injected](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanInjector.java) and [extracted](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanExtractor.java):
 
 #### Route based on the browser
 
@@ -118,13 +118,13 @@ istioctl create -f guestbook/route-rule-user-agent-chrome.yaml
 
 Test this by first navigating to the echo service in Chrome:
 
-http://35.197.94.184/echo/universe
+http://INGRESS_IP/echo/universe
 
 You should see:
 
 Hola test from helloworld-service-v2-87744028-x20j0 version 2.0
 
-If you then navigate to it another browser like firefox you will see:
+If you then navigate to it another browser like Firefox you will see:
 
 Hello sdsdffsd from helloworld-service-v1-4086392344-42q21 with 1.0
 

--- a/exercise-10/README.md
+++ b/exercise-10/README.md
@@ -70,48 +70,17 @@ Currently the routing rule only routes to `v1` of the hello world service which.
     weight: 20
 ```
 
-We'll do canary testing based on HTTP headers: if the user-agent is "mobile" it'll go to `v2`, otherwise requests will go to `v1`. Written as a route rule, this looks like:
-
+You can apply this rule from an existing configuration:
 ```sh
 istioctl create -f guestbook/route-rule-80-20.yaml
 ```
 
-```yaml
-destination:
-  name: helloworld-service
-match:
-  request:
-    headers:
-      user-agent:
-        exact: mobile
-precedence: 2
-route:
-  - labels:
-      version: "2.0"
-```
-
-Note that rules with a higher precedence number are applied first. If a precedence is not specified then it defaults to 0. So with these two rules in place the one with precedence 2 will be applied before the rule with precedence 1.
-
-Test this out by creating the rule:
-```sh
-istioctl create -f guestbook/route-rule-user-mobile.yaml
-```
-
-Now when you curl the end point set the user agent to be mobile and you should only see V2:
-
-```sh
-curl http://$INGRESS_IP/echo/universe -A mobile
-
-{"greeting":{"hostname":"helloworld-service-v2-3297856697-6m4bp","greeting":"Hello dog2 from helloworld-service-v2-3297856697-6m4bp with 2.0","version":"2.0"}
-```
-
+Then try a few calls to the service:
 ```sh
 curl http://$INGRESS_IP/echo/universe
 
 {"greeting":{"hostname":"helloworld-service-v1-286408581-9204h","greeting":"Hello universe from helloworld-service-v1-286408581-9204h with 1.0","version":"1.0"},"
 ```
-
-An important point to note is that the user-agent HTTP header is propagated in the span baggage. Look at these two classes for details on how the header is [injected](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanInjector.java) and [extracted](https://github.com/retroryan/istio-by-example-java/blob/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio/IstioHttpSpanExtractor.java):
 
 #### Route based on the browser
 

--- a/exercise-11/README.md
+++ b/exercise-11/README.md
@@ -43,11 +43,12 @@ istioctl create -f guestbook/mixer-rule-denial.yaml
 ```
 
 Verify that access is now denied:
+
 ```sh
 curl http://$INGRESS_IP/hello/world
 ```
 
-#### Block Access to v2 of the hello world service
+#### Block Access to v2 of the Hello World service
 
 ```yaml
 # The rule that uses denier to deny requests to version 2.0 of the helloworld service

--- a/exercise-12/README.md
+++ b/exercise-12/README.md
@@ -8,7 +8,7 @@ To test our guestbook application for resiliency, this exercise will test inject
 #### Inject a route rule to delay hello world
 
 
-We'll delay access to the Hello World service by adding the mixer-rule-denial.yaml rule that forces a delay:
+We'll delay access to the Hello World service by adding the `mixer-rule-denial.yaml` rule that forces a delay:
 
 ```yaml
 httpFault:
@@ -16,14 +16,16 @@ httpFault:
     percent: 100
     fixedDelay: 10s
   abort:
-      percent: 10
-      httpStatus: 400
+    percent: 10
+    httpStatus: 400
 ```
 
 Be sure the old route rule for mobile is removed before adding the delay.
 
 ```sh
 
+istioctl delete -f guestbook/route-rule-80-20.yaml
+istioctl delete -f guestbook/route-rule-user-agent-chrome.yaml
 istioctl delete -f guestbook/route-rule-user-mobile.yaml
 
 istioctl create -f guestbook/route-rule-delay-guestbook.yaml

--- a/exercise-12/README.md
+++ b/exercise-12/README.md
@@ -44,5 +44,4 @@ $ curl http://$INGRESS_IP/echo/universe -A mobile
 
 If you modify the delay below the timeout configured in the applciation the service will still return.  For example if we modify it to 4 seconds, the guestbook service still returns a response.
 
-
 #### [Continue to Exercise 13 - Security](../exercise-13/README.md)

--- a/exercise-13/README.md
+++ b/exercise-13/README.md
@@ -10,6 +10,7 @@ Let the past go. Kill it, if you have to:
 ```
 cd ~/istio
 kubectl delete -f install/kubernetes/istio.yaml
+kubectl delete all --all
 ```
 
 It's the only way for TLS to be the way it was meant to be:

--- a/exercise-13/README.md
+++ b/exercise-13/README.md
@@ -4,14 +4,15 @@
 
 Istio provides transparent, and frankly magical, mutal TLS to services inside the service mesh when asked. By mutual TLS we understand that both the client and the server authenticate each others certificates as part of the TLS handshake.
 
-#### Enable mutual tls
+#### Enable Mutual TLS
 
 Let the past go. Kill it, if you have to:
 ```
+cd ~/istio
 kubectl delete -f install/kubernetes/istio.yaml
 ```
 
-It's the only way for tls to be the way it was meant to be:
+It's the only way for TLS to be the way it was meant to be:
 
 ```
 # (from istio install root)
@@ -21,13 +22,15 @@ kubectl create -f install/kubernetes/istio-auth.yaml
 We need to (re)create the auto injector. There is a script bundled that will do this but you will need to switch back to _this_ directory and give it the location of your istio install. Or you can redo the steps from exercise 6. Your call.
 
 ```
-./install-auto-injector.sh ../../istio-0.5.0
+cd ~/istio-workshop/exercise-13
+./install-auto-injector.sh ~/istio
 ```
 
-Finally enable injection and deploy the thrilling book info sample.
+Finally enable injection and deploy the thrilling Book Info sample.
 
 ```
 # (from istio install root)
+cd ~/istio
 kubectl label namespace default istio-injection=enabled
 kubectl create -f samples/bookinfo/kube/bookinfo.yaml
 ```
@@ -60,8 +63,8 @@ Let's exfiltrate the certificates out of a proxy so we can pretend to be them (i
 
 ```
 pp=$(kubectl get po -l app=productpage -o template --template '{{(index .items 0).metadata.name}}')
-mkdir tmp # or wherever you want to stash these certs
-cd tmp
+mkdir ~/tmp # or wherever you want to stash these certs
+cd ~/tmp
 fs=(key.pem cert-chain.pem root-cert.pem)
 for f in ${fs[@]}; do kubectl exec -c istio-proxy $pp /bin/cat -- /etc/certs/$f >$f; done
 ```
@@ -88,3 +91,5 @@ kubectl exec -it $tb curl -- http://details:9080/details/0
 ```
 
 Notice the protocol.
+
+#### [Continue to Exercise 14 - Ensuring security with iptables](../exercise-14/README.md)

--- a/exercise-14/README.md
+++ b/exercise-14/README.md
@@ -97,3 +97,5 @@ This effectively forces all traffic to run through the proxy without any coopera
 #### When did that happen?
 
 The init container that istio injects runs a small script to setup this rules with NET\_CAP\_ADMIN. Neat, eh?
+
+#### [Continue to Exercise 15 - mTLS again, now with 100% more SPIFFE](../exercise-15/README.md)

--- a/exercise-15/README.md
+++ b/exercise-15/README.md
@@ -1,8 +1,9 @@
 ## Exercise 15 - mTLS again, now with 100% more SPIFFE
 
-Istio uses SPIFFE to assert the identify of workloads on the cluster. SPIFFE is a very simple standard. It consists of a notion of identity and a method of proving it. A SPIFFE identity consists of an authority part and a path. The meaning of the path in spiffe land is implementation defined. In k8s it takes the form `/ns/$namespace/sa/$service-account` with the expected meaning. A SPIFFE identify is embedded in a document. This document in principle can take many forms but currently the only defined format is x509. Let's see what an SPIFFE x509 looks like. Remember those certificates we stole earlier? Execute the below snippet either in the directory where you have the certificates locally, if you have openssl installed. If you don't you can install it in the toolbox centos image with with `yum install -y openssl`.
+Istio uses SPIFFE to assert the identify of workloads on the cluster. SPIFFE is a very simple standard. It consists of a notion of identity and a method of proving it. A SPIFFE identity consists of an authority part and a path. The meaning of the path in spiffe land is implementation defined. In k8s it takes the form `/ns/$namespace/sa/$service-account` with the expected meaning. A SPIFFE identify is embedded in a document. This document in principle can take many forms but currently the only defined format is x509. Let's see what an SPIFFE x509 looks like. Remember those certificates we stole earlier? Execute the below snippet either in the directory where you have the certificates locally, if you have `openssl` installed.
 
 ```
+cd ~/tmp
 openssl x509 -in cert-chain.pem -text | less
 ```
 
@@ -12,10 +13,12 @@ The important thing to notice is that the subject isn't what you'd normally expe
 openssl verify -show_chain -CAfile root-cert.pem cert-chain.pem
 ```
 
-You might need to drop the `-show-chain` argument depending on what version of openssl you have installed.  Depending on how long it's been since the certs were extracted they might be out of date. Istio rolls certificates aggressively.
+You might need to drop the `-show-chain` argument depending on what version of openssl you have installed.  Depending on how long it's been since the certificates were extracted they might be out of date. Istio rolls certificates aggressively.
 
 #### Why?
 
-The istio proxy uses the SPIFFE identity to establish secure authenticated communication channels over TLS. By providing identities on both the client and server side it establishes mTLS. The service account is also made available as an attribute in mixer.
+The Istio proxy uses the SPIFFE identity to establish secure authenticated communication channels over TLS. By providing identities on both the client and server side it establishes mTLS. The service account is also made available as an attribute in mixer.
 
 Interested parties can find the SPIFFE specification https://github.com/spiffe/spiffe. It's very readable. 
+
+#### [Continue to Exercise 16 - Istio RBAC](../exercise-16/README.md)

--- a/exercise-16/README.md
+++ b/exercise-16/README.md
@@ -2,11 +2,11 @@
 
 #### Mixer all the way down
 
-Istio has an rbac engine implemented as a mixer adapter. There are a number of things that need to be configured before it can be turned loose on unsuspecting services.
+Istio has an RBAC engine implemented as a mixer adapter. There are a number of things that need to be configured before it can be turned loose on unsuspecting services.
 
 #### Who did what
 
-The founddation is an instance of an authorization template. The purpose of the auth template is to select from the attribute vocabulary available a subset that will be endowed with specific meaning for rbac. Consider subject selection; who is making the request? This could be extracted from a header, from the spiffe uri, from a cookie etc etc. The authorization template is what specifies this.
+The founddation is an instance of an authorization template. The purpose of the auth template is to select from the attribute vocabulary available a subset that will be endowed with specific meaning for RBAC. Consider subject selection; who is making the request? This could be extracted from a header, from the SPIFFE URI, from a cookie etc etc. The authorization template is what specifies this.
 
 Example usage:
 
@@ -34,7 +34,7 @@ spec:
       version: destination.labels["version"] | ""
 ```
 
-Subject is the who, action is the what. In this instance will we be using the _service account_ as the user, which will allow us to take advantage of spiffe identity asserted by our x509 certificates. We also take advantage of properies to include metadata in our auth decisions, for instance the app label.
+Subject is the who, action is the what. In this instance will we be using the _service account_ as the user, which will allow us to take advantage of SPIFFE identity asserted by our x509 certificates. We also take advantage of properies to include metadata in our auth decisions, for instance the app label.
 
 #### The binding of services
 
@@ -109,10 +109,11 @@ spec:
 
 #### Switching it on
 
-There are some files missing from the istio release that we require to do this exercise. You can obtain them by running the `pull-files.sh` script in this directory. It takes one argument, which should be the _root_ directory of your unpacked istio release.
+There are some files missing from the Istio release that we require to do this exercise. You can obtain them by running the `pull-files.sh` script in this directory. It takes one argument, which should be the _root_ directory of your unpacked Istio release.
 
 ```
-$ ./pull-files.sh ../../istio-0.5.0
+$ cd ~/istio-workshop/exercise-16/
+$ ./pull-files.sh ~/istio
 Copying rbac samples to /home/ben/src/work/grcl/istio-0.5.0/samples/bookinfo/kube, continue? [Y/n] 
 Copying...
 
@@ -120,9 +121,10 @@ Copying...
 
 ```
 
-Once we have these samples we can continue. Assume all other shell is run with the working directory set to the istio release root.
+Once we have these samples we can continue. Assume all other shell is run with the working directory set to the Istio release root.
 
 ```
+cd ~/istio
 kubectl apply -f samples/bookinfo/kube/bookinfo-add-serviceaccount.yaml
 kubectl apply -f samples/bookinfo/kube/istio-rbac-enable.yaml
 ```
@@ -130,8 +132,8 @@ kubectl apply -f samples/bookinfo/kube/istio-rbac-enable.yaml
 Now we should get denied for all the things:
 
 ```
-ingress_ip=$(kubectl get ingress -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}')
-curl http://$ingress_ip/productpage
+INGRESS_IP=$(kubectl get ingress -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}')
+curl http://$INGRESS_IP/productpage
 ```
 
 We can let ourselves back in with some roles / bindings.

--- a/exercise-2/README.md
+++ b/exercise-2/README.md
@@ -2,7 +2,7 @@
 
 #### Deploy Hello World
 
-1 - Deploy hello world service to kubernetes
+1 - Deploy Hello World service to Kubernetes
 
 ```sh
 cd istio-workshop
@@ -12,12 +12,12 @@ kubectl apply -f kubernetes/helloworldservice-deployment.yaml --record
 kubectl get pods
 
 NAME                           READY     STATUS    RESTARTS    AGE
-helloworld-service-v1-....    1/1       Running   0           20s
+helloworld-service-v1-....     1/1       Running   0           20s
 ```
 
 An important detail to note is that READY shows 1/1.  That is referring to the number of containers in the pod that are ready and this pod only has 1 container. 
 
-2 -  Note the name of the pod above for use in the command below. Then delete one of the hello world pods.
+2 - Note the name of the pod above for use in the command below. Then delete one of the hello world pods.
 
 ```sh
 kubectl delete pod helloworld-service-v1-...

--- a/exercise-4/README.md
+++ b/exercise-4/README.md
@@ -56,7 +56,7 @@ If you look at the pod status, some of the pods will show a `Pending` state. Tha
     Open another terminal and run:
 
     ```
-    kubectl get po -w -o wide
+    kubectl get pods -w -o wide
     ```
 
     This will monitor the recovering process.
@@ -68,5 +68,12 @@ If you look at the pod status, some of the pods will show a `Pending` state. Tha
     kubectl get pods -o wide
     ```
 
+6. Scale back the number of replicas before moving on!
+
+    ```
+    kubectl scale deployment helloworld-service-v1 --replicas=2
+    ```
+
+    Kubernetes will only keep 2 of the Hello World instances and terminate the rest.
 
 #### [Continue to Exercise 4a - Envoy](../exercise-4a/README.md)

--- a/exercise-4a/README.md
+++ b/exercise-4a/README.md
@@ -22,16 +22,22 @@ Run httpbin and expose port 8000:
 
 ```sh
 docker run -it --name httpbin -p 8000:8000 --rm citizenstig/httpbin
+```
+
+In another shell tab, curl for headers:
+
+```sh
 curl localhost:8000/headers
 ```
 
-
-Run envoy using the sample config in guestbook directory.  
+Run envoy using the sample config in guestbook directory.
 
 To share the config with docker you need to first open the docker preferences and add the guestbook directory.
 
+In a 3rd shell tab, run Envoy:
 
 ```sh
+cd ~/istio-workshop/
 docker run -it --rm envoyproxy/envoy envoy --help
 docker run -it --name proxy --link httpbin \
   -p 15000:15000 -p 15001:15001 \
@@ -39,19 +45,19 @@ docker run -it --name proxy --link httpbin \
   envoyproxy/envoy envoy -c /etc/simple.json
 ```
 
-curl the envoy proxy:
+curl the Envoy proxy on port `15001`:
 
 ```sh
-curl  -X GET http://localhost:15001/headers
+curl -s http://localhost:15001/headers
 ```
 
 Notice that Envoy added a X-Request-Id
 
-Curl the envoy admin stats and then zero in on the retry count:
+Curl the Envoy admin stats and then zero in on the retry count:
 
 ```sh
-curl -X GET http://localhost:15000/stats
-curl -X GET http://localhost:15000/stats | grep retry
+curl -s http://localhost:15000/stats
+curl -s http://localhost:15000/stats | grep retry
 ```
 
 In the simple json the retry policy for 5xx is set to:
@@ -64,13 +70,12 @@ In the simple json the retry policy for 5xx is set to:
 If you trigger a 500 you can see the retry count go up:
 
 ```sh
-curl -X GET http://localhost:15001/status/500
-curl -X GET http://localhost:15001/status/500
-curl -X GET http://localhost:15001/status/500
-curl -X GET http://localhost:15001/status/500
-curl -X GET http://localhost:15001/status/500
-curl -X GET http://localhost:15000/stats | grep retry
+curl -s http://localhost:15001/status/500
+curl -s http://localhost:15001/status/500
+curl -s http://localhost:15001/status/500
+curl -s http://localhost:15001/status/500
+curl -s http://localhost:15001/status/500
+curl -s http://localhost:15000/stats | grep retry
 ```
-
 
 #### [Continue to Exercise 5 - Installing Istio](../exercise-5/README.md)

--- a/exercise-5/README.md
+++ b/exercise-5/README.md
@@ -1,6 +1,4 @@
-## Exercise 5 - Installing Istio 0.5.0
-
-We are using Istio 0.5.0 because of bugs with route rules in Istio 0.5.1  !
+## Exercise 5 - Installing Istio 0.6.0
 
 #### Clean up
 
@@ -10,16 +8,28 @@ Start with a clean slate and delete all deployed services from the cluster:
 kubectl delete all --all
 ```
 
-#### Download Istio 0.5.0
+#### Download Istio 0.6.0
 
-Do NOT download the latest release of istio.  Be sure to download Istio 0.5.0
+Download Istio 0.6.0 from the following website:
 
-Download Istio from the following website:
+https://github.com/istio/istio/releases/tag/0.6.0
 
-https://github.com/istio/istio/releases
+For example, in Cloud Shell, you can install Istio to the home directory:
 
 ```sh
-export PATH=$PWD/istio-0.5.0/bin:$PATH
+cd ~/
+wget https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz
+tar -xzvf istio-0.6.0-linux.tar.gz
+ln -sf ~/istio-0.6.0 ~/istio
+```
+
+```sh
+export PATH=~/istio/bin:$PATH
+```
+
+Also, save it in `.bashrc` in case you restart your shell:
+```sh
+echo 'export PATH=~/istio/bin:$PATH' >> ~/.bashrc
 ```
 
 #### Running istioctl
@@ -46,17 +56,17 @@ For this workshop we are not using Istio Auth because we want to test using outs
 To install plain istio run:
 
 ```sh
-kubectl apply -f istio-0.5.0/install/kubernetes/istio.yaml
+kubectl apply -f ~/istio/install/kubernetes/istio.yaml
 ```
 
 
 ####  Install Add-ons for Grafana, Prometheus, and Zipkin:
 
 ```sh
-kubectl apply -f istio-0.5.0/install/kubernetes/addons/zipkin.yaml
-kubectl apply -f istio-0.5.0/install/kubernetes/addons/grafana.yaml
-kubectl apply -f istio-0.5.0/install/kubernetes/addons/prometheus.yaml
-kubectl apply -f istio-0.5.0/install/kubernetes/addons/servicegraph.yaml
+kubectl apply -f ~/istio/install/kubernetes/addons/zipkin.yaml
+kubectl apply -f ~/istio/install/kubernetes/addons/grafana.yaml
+kubectl apply -f ~/istio/install/kubernetes/addons/prometheus.yaml
+kubectl apply -f ~/istio/install/kubernetes/addons/servicegraph.yaml
 ```
 
 #### Viewing the Istio Deployments
@@ -64,10 +74,8 @@ kubectl apply -f istio-0.5.0/install/kubernetes/addons/servicegraph.yaml
 Istio is deployed in a separate Kubernetes namespace `istio-system`  You can watch the state of Istio and other services and pods using the watch flag (`-w`) when listing Kubernetes resources. For example, in two separate terminal windows run:
 
 ```sh
-kubectl get pods -w --all-namespaces
-```
-```sh
-kubectl get services -w --all-namespaces
+kubectl get pods -n istio-system -w
+kubectl get services -n istio-system -w
 ```
 
 #### [Continue to Exercise 6 - Creating a Service Mesh with Istio Proxy](../exercise-6/README.md)

--- a/exercise-6/README.md
+++ b/exercise-6/README.md
@@ -44,17 +44,10 @@ For Istio the webhook is the sidecar injector webhook deployment called "istio-s
 
 #### Installing the Webhook
 
-The Istio 0.5.0 and 0.5.1 releases are missing scripts to provision webhook certificates.  The easiest fix  is to download the scripts directly into the Istio install directories:
-
 Webhooks requires a signed cert/key pair. Use install/kubernetes/webhook-create-signed-cert.sh to generate a cert/key pair signed by the Kubernetes’ CA. The resulting cert/key file is stored as a Kubernetes secret for the sidecar injector webhook to consume.
 
 ```sh
-cd istio-0.5.0/install/kubernetes
-wget https://raw.githubusercontent.com/istio/istio/master/install/kubernetes/webhook-create-signed-cert.sh
-
-wget https://raw.githubusercontent.com/istio/istio/master/install/kubernetes/webhook-patch-ca-bundle.sh
-
-chmod a+x *.sh
+cd ~/istio/install/kubernetes
 
 ./webhook-create-signed-cert.sh \
     --service istio-sidecar-injector \
@@ -106,7 +99,6 @@ kube-public    Active    1h
 kube-system    Active    1h
 ```
 
-
 ### Deploy Guestbook services
 
 To demonstrate Istio, we’re going to use [this guestbook example](https://github.com/retroryan/spring-boot-docker). This example is built with Spring Boot, a frontend using Spring MVC and Thymeleaf, and two microservices. The 3 microservices that we are going to deploy are:
@@ -124,14 +116,14 @@ Note that the services must be started in a fixed order because they depend on o
 1. Deploy MySQL, Redis, the Hello World microservices, and the associated Kubernetes Services from the `istio-workshop` dir:
 
     ```sh
-    cd istio-workshop
+    cd ~/istio-workshop
     kubectl apply -f guestbook/mysql-deployment.yaml -f guestbook/mysql-service.yaml
     kubectl apply -f guestbook/redis-deployment.yaml -f guestbook/redis-service.yaml
     kubectl apply -f guestbook/helloworld-deployment.yaml -f guestbook/helloworld-service.yaml
     kubectl apply -f guestbook/helloworld-deployment-v2.yaml
     ```
 
-2. Notice that each of the pods now has one istio init container and two running containers. One is the main application container and the second is the istio proxy container.
+2. Notice that each of the pods now has one Istio init container and two running containers. One is the main application container and the second is the istio proxy container.
 
 ```sh
 kubectl get pod
@@ -174,6 +166,7 @@ The guestbook UI kubernetes service has a type of LoadBalancer.  This creates an
 
 ```sh
 kubectl get svc guestbook-ui
+
 NAME           TYPE           CLUSTER-IP     EXTERNAL-IP     PORT(S)        AGE
 guestbook-ui   LoadBalancer   10.59.245.13   35.197.94.184   80:30471/TCP   2m
 ```
@@ -186,7 +179,7 @@ To curl the guest book endpoint use:
 curl 35.230.4.192/echo/world
 ```
 
-Also the hello world service is declared with an external ip which can be curled:
+Also the Hello World service is declared with an external ip which can be curled:
 
 ```sh
 kubectl get svc helloworld-service
@@ -206,6 +199,7 @@ kubectl describe pod helloworld-service-v1.....
 kubectl exec -it helloworld-service-v1..... -c istio-proxy bash
 cd /etc/istio/proxy
 more envoy-rev6.json
+exit
 ```
 
 #### [Continue to Exercise 7 - Istio Ingress controller](../exercise-7/README.md)

--- a/exercise-7/README.md
+++ b/exercise-7/README.md
@@ -15,8 +15,14 @@ kubectl get svc istio-ingress -n istio-system -o yaml
 Because the Istio Ingress Controller is an Envoy Proxy you can inspect it using the admin routes.  First find the name of the istio ingress proxy:
 
 ```sh
-kubectl get po -n istio-system
-kubectl port-forward istio-ingress-d8d5fdc86-69jtx -n istio-system 15000:15000
+kubectl get pods -n istio-system
+kubectl port-forward istio-ingress-... -n istio-system 15000:15000
+```
+
+If you see a bind error because port `15000` is already used, it's probably the Envoy proxy from previous exercise that's still running locally. Kill the local Envoy proxy:
+
+```sh
+docker kill proxy
 ```
 
 You can view the statistics, listeners, routes, clusters and server info for the envoy proxy by forwarding the local port:
@@ -32,14 +38,13 @@ curl localhost:15000/server_info
 
 See the [admin docs](https://www.envoyproxy.io/docs/envoy/v1.5.0/operations/admin) for more details.
 
-
-Also it can be helpful to look at the log files of the istio ingress controller to see what request is being routed.  First find the ingress pod and the output the log files:
+Also it can be helpful to look at the log files of the Istio ingress controller to see what request is being routed.  First find the ingress pod and the output the log files:
 
 ```sh
-kubectl logs istio-ingress-d8d5fdc86-69jtx -n istio-system
+kubectl logs istio-ingress-... -n istio-system
 ```
 
-#### Configure Guess Book Ingress Routes with the Istio Ingress Controller
+#### Configure Guest Book Ingress Routes with the Istio Ingress Controller
 
 1 - Configure the Guess Book UI default route with the Istio Ingress Controller:
 
@@ -82,13 +87,22 @@ NAMESPACE      NAME                   CLUSTER-IP      EXTERNAL-IP      PORT(S)  
 istio-system   istio-ingress          10.31.244.185   35.188.171.180   80:31920/TCP,443:32165/TCP    1h
 ```
 
+Once the Ingress is successfully configured, you can also get the Ingress IP doing:
+
+```sh
+kubectl get ingress
+
+NAME             HOSTS     ADDRESS          PORTS     AGE
+simple-ingress   *         35.224.145.187   80        2m
+```
+
 ```sh
 export INGRESS_IP=$(kubectl get service istio-ingress -n istio-system --template="{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}")
 ```
 
 3 - Browse to the website of the guest Book using the INGRESS IP to see the Guest Book UI: `http://INGRESS_IP`
 
-4 - You can also access the hello world service and see the json in the browser:
+4 - You can also access the Hello World service and see the json in the browser:
 `http://INGRESS_IP/hello/world`
 
 
@@ -97,12 +111,12 @@ export INGRESS_IP=$(kubectl get service istio-ingress -n istio-system --template
 curl http://$INGRESS_IP/echo/universe
 ```
 
-And the hello world service:
+And the Hello World service:
 ```
 curl http://$INGRESS_IP/hello/world
 ```
 
-6 - Then curl the echo endpoint multiple times and notice how it round robins between v1 and v2 of the hello world service:
+6 - Then curl the echo endpoint multiple times and notice how it round robins between v1 and v2 of the Hello World service:
 
 ```sh
 curl http://$INGRESS_IP/echo/universe
@@ -114,16 +128,15 @@ curl http://$INGRESS_IP/echo/universe
 curl http://$INGRESS_IP/echo/universe
 
 {"greeting":{"hostname":"helloworld-service-v2-1009285752-n2tpb","greeting":"Hello universe from helloworld-service-v2-1009285752-n2tpb with 2.0","version":"2.0"}
-
 ```
 
-#### Inspecting the Istio proxy of the hello world service pod
+#### Inspecting the Istio proxy of the Hello World service pod
 
 To better understand the istio proxy, let's inspect the details.  exec into the hellworld service pod to find the proxy details.  First find the full pod name and then exec into the istio-proxy container:
 
 ```sh
-kubectl get po
-kubectl exec -it helloworld-service-v1-fd94c8576-5ttqc -c istio-proxy  sh
+kubectl get pods
+kubectl exec -it helloworld-service-v1-... -c istio-proxy  sh
 ```
 
 Once in the container look at some of the envoy proxy details:
@@ -137,7 +150,7 @@ $  cat /etc/istio/proxy/envoy-rev0.json
 You can also view the statistics, listeners, routes, clusters and server info for the envoy proxy by forwarding the local port:
 
 ```sh
-kubectl port-forward helloworld-service-v1-fd94c8576-5ttqc 15000:15000
+kubectl port-forward helloworld-service-v1-... 15000:15000
 curl localhost:15000/stats
 curl localhost:15000/listeners
 curl localhost:15000/routes
@@ -146,7 +159,5 @@ curl localhost:15000/server_info
 ```
 
 See the [admin docs](https://www.envoyproxy.io/docs/envoy/v1.5.0/operations/admin) for more details.
-
-
 
 #### [Exercise 8 - Telemetry](../exercise-8/README.md)

--- a/exercise-8/README.md
+++ b/exercise-8/README.md
@@ -1,33 +1,15 @@
 ## Exercise 8 - Telemetry
 
-First we need to configure Istio to automatically gather telemetry data for services running in the mesh.
-
-This is done by adding Istio configuration that instructs Mixer to automatically generate and report a new metric and a new log stream for all traffic within the mesh.
-
-The added configuration controlls three pieces of Mixer functionality:
-
-* Generation of instances (in this example, metric values and log entries) from Istio attributes
-* Creation of handlers (configured Mixer adapters) capable of processing generated instances
-* Dispatch of instances to handlers according to a set of rules
-
-
-The metrics configuration directs Mixer to send metric values to Prometheus. It uses three stanzas (or blocks) of configuration: instance configuration, handler configuration, and rule configuration.
-
-#### Create a Rule to Collect Telemetry Data
-
-```sh
-istioctl create -f guestbook/guestbook-telemetry.yaml
-```
-#### View Guestbook Telemetry data
+#### Generate Guestbook Telemetry data
 
 Generate a small load to the application either using wrk2 or a shell script:
 
 For wrk2:
 
 ```sh
- brew install --HEAD jabley/wrk2/wrk2
-
-wrk -d 500s -c 5 -t 5 http://$INGRESS_IP/hello/world
+docker pull saturnism/wrk2
+docker run -ti --rm saturnism/wrk2 \
+  -d 500s -c 5 -t 5 http://$INGRESS_IP/hello/world
 ```
 
 Or a shell script:
@@ -43,7 +25,7 @@ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=gr
   -o jsonpath='{.items[0].metadata.name}') 3000:3000
 ```
 
-Browse to http://localhost:3000 and navigate to Istio Dashboard
+If you are in Cloud Shell, you'll need to use Web Preview and Change Port to `3000`. Else, browse to http://localhost:3000 and navigate to Istio Dashboard
 
 ### Prometheus
 ```sh
@@ -52,10 +34,9 @@ kubectl -n istio-system port-forward \
   9090:9090
 ```
 
-Browse to http://localhost:9090/graph and in the “Expression” input box enter: `istio_request_count`. Click the Execute button.
+If you are in Cloud Shell, you'll need to use Web Preview and Change Port to `9090`.  Else, browse to http://localhost:9090/graph and in the “Expression” input box enter: `istio_request_count`. Click the Execute button.
 
-
-### Service Graph  - Broken in Istio 0.5.0
+### Service Graph
 
 ```sh
 kubectl -n istio-system port-forward \
@@ -63,15 +44,8 @@ kubectl -n istio-system port-forward \
   8088:8088
 ```
 
-Browse to http://localhost:8088/dotviz
+If you are in Cloud Shell, you'll need to use Web Preview and Change Port to `9090`. Once opened, you'll see `404 not found` error. This is normal because `/` is not handled. Append the URI with `/dotviz`, e.g.: `http://8088-dot-...-dot-devshell.appspot.com/dotviz`
 
-#### Mixer Log Stream
-
-The logs configuration directs Mixer to send log entries to stdout. It uses three stanzas (or blocks) of configuration: instance configuration, handler configuration, and rule configuration.
-
-
-```sh
-kubectl -n istio-system logs -f $(kubectl -n istio-system get pods -l istio=mixer -o jsonpath='{.items[0].metadata.name}') mixer | grep \"instance\":\"newlog.logentry.istio-system\"
-```
+Else, browse to http://localhost:8088/dotviz
 
 #### [Continue to Exercise 9 - Distributed Tracing](../exercise-9/README.md)

--- a/exercise-8/README.md
+++ b/exercise-8/README.md
@@ -4,18 +4,18 @@
 
 Generate a small load to the application either using wrk2 or a shell script:
 
-For wrk2:
+With simple shell script:
+
+```sh
+while sleep 0.5; do curl http://$INGRESS_IP/hello/world; done
+```
+
+Or, with wrk2:
 
 ```sh
 docker pull saturnism/wrk2
 docker run -ti --rm saturnism/wrk2 \
-  -d 500s -c 5 -t 5 http://$INGRESS_IP/hello/world
-```
-
-Or a shell script:
-
-```sh
-while sleep 0.5; do curl http://$INGRESS_IP/hello/world; done
+  -d 5s -R 5 http://$INGRESS_IP/hello/world
 ```
 
 ### Grafana

--- a/exercise-8a/README.md
+++ b/exercise-8a/README.md
@@ -1,0 +1,29 @@
+## Exercise 8a - Additional Telemetry and Log
+
+First we need to configure Istio to automatically gather telemetry data for services running in the mesh.
+
+This is done by adding Istio configuration that instructs Mixer to automatically generate and report a new metric and a new log stream for all traffic within the mesh.
+
+The added configuration controlls three pieces of Mixer functionality:
+
+* Generation of instances (in this example, metric values and log entries) from Istio attributes
+* Creation of handlers (configured Mixer adapters) capable of processing generated instances
+* Dispatch of instances to handlers according to a set of rules
+
+The metrics configuration directs Mixer to send metric values to Prometheus. It uses three stanzas (or blocks) of configuration: instance configuration, handler configuration, and rule configuration.
+
+#### Create a Rule to Collect Telemetry Data
+
+```sh
+istioctl create -f guestbook/guestbook-telemetry.yaml
+```
+
+#### Mixer Log Stream
+
+The logs configuration directs Mixer to send log entries to stdout. It uses three stanzas (or blocks) of configuration: instance configuration, handler configuration, and rule configuration.
+
+```sh
+kubectl -n istio-system logs -f $(kubectl -n istio-system get pods -l istio=mixer -o jsonpath='{.items[0].metadata.name}') mixer | grep \"instance\":\"newlog.logentry.istio-system\"
+```
+
+#### [Continue to Exercise 9 - Distributed Tracing](../exercise-9/README.md)

--- a/exercise-9/README.md
+++ b/exercise-9/README.md
@@ -22,18 +22,18 @@ https://github.com/retroryan/istio-by-example-java/tree/master/spring-boot-examp
 
 Generate a small load to the application either using wrk2 or a shell script:
 
-For wrk2:
+With shell script:
+
+```sh
+while sleep 0.5; do curl http://$INGRESS_IP/echo/universe -A mobile; done
+```
+
+Or, with wrk2:
 
 ```sh
 docker pull saturnism/wrk2
 docker run -ti --rm saturnism/wrk2 \
-  -d 500s -c 5 -t 5 http://$INGRESS_IP/hello/world
-```
-
-Or a shell script:
-
-```sh
-while sleep 0.5; do curl http://$INGRESS_IP/echo/universe -A mobile; done
+  -d 5s R 5 http://$INGRESS_IP/hello/world
 ```
 
 ### Zipkin

--- a/exercise-9/README.md
+++ b/exercise-9/README.md
@@ -18,8 +18,6 @@ This is done with the Spring Istio Support written by Ray Tsang:
 
 https://github.com/retroryan/istio-by-example-java/tree/master/spring-boot-example/spring-istio-support/src/main/java/com/example/istio
 
-
-
 #### View Guestbook Traces
 
 Generate a small load to the application either using wrk2 or a shell script:
@@ -27,9 +25,9 @@ Generate a small load to the application either using wrk2 or a shell script:
 For wrk2:
 
 ```sh
- brew install --HEAD jabley/wrk2/wrk2
-
-wrk -d 500s -c 5 -t 5 http://$INGRESS_IP/hello/world
+docker pull saturnism/wrk2
+docker run -ti --rm saturnism/wrk2 \
+  -d 500s -c 5 -t 5 http://$INGRESS_IP/hello/world
 ```
 
 Or a shell script:
@@ -39,13 +37,14 @@ while sleep 0.5; do curl http://$INGRESS_IP/echo/universe -A mobile; done
 ```
 
 ### Zipkin
-Establish port forward from local port
+Establish port forward from local port:
+
 ```sh
 kubectl port-forward -n istio-system \
   $(kubectl get pod -n istio-system -l app=zipkin -o jsonpath='{.items[0].metadata.name}') \
   9411:9411
 ```
 
-Browse to http://localhost:9411
+f you are in Cloud Shell, you'll need to use Web Preview and Change   Port to `9411`. Else, browse to http://localhost:9411
 
 #### [Continue to Exercise 10 - Request Routing and Canary Testing](../exercise-10/README.md)

--- a/exercise-9/README.md
+++ b/exercise-9/README.md
@@ -6,13 +6,13 @@ Although Istio proxies are able to automatically send spans, it needs help from 
 
 To do this the guestbook application collects and propagate the following headers from the incoming request to any outgoing requests:
 
-x-request-id
-x-b3-traceid
-x-b3-spanid
-x-b3-parentspanid
-x-b3-sampled
-x-b3-flags
-x-ot-span-context
+- `x-request-id`
+- `x-b3-traceid`
+- `x-b3-spanid`
+- `x-b3-parentspanid`
+- `x-b3-sampled`
+- `x-b3-flags`
+- `x-ot-span-context`
 
 This is done with the Spring Istio Support written by Ray Tsang:
 

--- a/guestbook/route-rule-80-20.yaml
+++ b/guestbook/route-rule-80-20.yaml
@@ -1,7 +1,10 @@
-type: route-rule
-name: route8020-helloworld-service
+apiVersion: config.istio.io/v1alpha2
+kind: RouteRule
+metadata:
+  name: route-rule-80-20
 spec:
-  destination: helloworld-service.default.svc.cluster.local
+  destination:
+    name: helloworld-service
   precedence: 1
   route:
   - tags:

--- a/guestbook/route-rule-80-20.yaml
+++ b/guestbook/route-rule-80-20.yaml
@@ -7,9 +7,9 @@ spec:
     name: helloworld-service
   precedence: 1
   route:
-  - tags:
+  - labels:
       version: "1.0"
     weight: 80
-  - tags:
+  - labels:
       version: "2.0"
     weight: 20

--- a/setup/README.md
+++ b/setup/README.md
@@ -45,8 +45,10 @@ This workshop can either be run all locally using the following setup instructio
 If you already have an installation of kubectl in your computer you can skip this step.
 
 ## Get the Workshop Source:
+  
+Clone from the current repository, e.g.
 
-  `git clone https://github.com/saturnism/istio-workshop`
+  `git clone https://github.com/THIS_REPOSITORY/istio-workshop`
 
 #### Windows Setup
 

--- a/setup/README.md
+++ b/setup/README.md
@@ -12,18 +12,9 @@ If you were provided with a Google Cloud Lab username setup the account by:
 
 ![Google Cloud Console Setup](../images/homescreen.png)
 
-2 - Select the ScaleBay SFO [SOME_NUMBER] project:
+2 - Select the only Google Cloud Platform project in the project list. If you don't see a project, let the instructor know!
 
 ![Google Cloud Console Setup 2](../images/homescreen2.png)
-
-### Google Cloud
-
-You must set your default compute service account to include:
-
-* `roles/container.admin (Kubernetes Engine Admin)`
-* `Editor (on by default)`
-
-To set this, navigate to the IAM section of the Cloud Console and find your default GCE/GKE service account in the following form: projectNumber-compute@developer.gserviceaccount.com: by default it should just have the Editor role. Then in the Roles drop-down list for that account, find the Kubernetes Engine group and select the role Kubernetes Engine Admin. The Roles listing for your account will change to Multiple.
 
 ##  Google Cloud Shell or Local Install
 
@@ -55,7 +46,7 @@ If you already have an installation of kubectl in your computer you can skip thi
 
 ## Get the Workshop Source:
 
-  `git clone https://github.com/retroryan/istio-workshop`
+  `git clone https://github.com/saturnism/istio-workshop`
 
 #### Windows Setup
 


### PR DESCRIPTION
No major issues.
- Upgraded to 0.6.0
- Increased consistency
- More instructions for Cloud Shell when checking Grafana, Prometheus, Zipkin
- Moved custom telemetry/log out of exercise 8 to exercise 8a; It feels like custom telemetry may cloud the main goal which is to see Grafana, Prometheus. Exercise 8a will need to have more details on how to verify and/or customize the metrics.